### PR TITLE
Replace https with http for mathbook.io urls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,12 +17,12 @@ There is always something to do to help maintain and grow Mathbook. You can,
 
 ## I want to create a tutorial for Mathbook.
 
-You can read up on how to create and submit a tutorial [here](https://mathbook.io/contribute/create-tutorial').
+You can read up on how to create and submit a tutorial [here](http://mathbook.io/contribute/create-tutorial').
 
 ## I want to review a tutorial submitted for review.
 
 You can read up on the process currently set up for reviewing a tutorial
-[here](https://mathbook.io/contribute/review-tutorial).
+[here](http://mathbook.io/contribute/review-tutorial).
 
 ## I want to report a bug I found.
 


### PR DESCRIPTION
Since the site doesn't currently support https, just switched out the urls w/ http so the pages load